### PR TITLE
fix: Update Query DSL version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <junit.version>5.11.3</junit.version>
     <mockito.version>5.14.2</mockito.version>
     <jackson.version>2.18.1</jackson.version>
-    <querydsl.version>6.8</querydsl.version>
+    <querydsl.version>6.10.1</querydsl.version>
     <jakarta.version>3.1.0</jakarta.version>
     <rxjava.version>2.2.21</rxjava.version>
 


### PR DESCRIPTION
- Bump Query DSL version to 6.10.1 to mitigate CVE-2024-49203

Ref: https://github.com/OpenFeign/querydsl/security/advisories/GHSA-6q3q-6v5j-h6vg