### PR TITLE
feat: add RQL filter pre-processors for simplifying expressions

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,5 +14,6 @@ The following people have contributed to this repository:
 * Dominic Schabel
 * Nikolai Wiens
 * Bodgan Toma
+* Istvan Zoltan Nagy
 
 Please add yourself to this list, if you contribute to the content.

--- a/documentation/modules/rql/pages/developer-guide.adoc
+++ b/documentation/modules/rql/pages/developer-guide.adoc
@@ -196,6 +196,28 @@ This can be expressed elegantly using the following construct:
 <4> The deferral is needed so another request is only made after we get to this element.
 Otherwise, a `.take(15)` further up the stream would not take effect until all elements had been fetched.
 
+==== Pre-processing RQL filters
+
+You can pre-process the parsed RQL filters to automatically simplify or transform them using a list of pre-defined pre-processors.
+This can be very useful for eliminating common mistakes in user input, for example transforming `not(ne(att1,"value"))` into `eq(att1,"value")`, or simplify expressions like `and(ne(attr1,"val1"),ne(attr1,"val2"))` to `not(in(attr1,"val1","val2"))`; or `or(eq(attr1,"val1"),eq(attr1,"val2"))` to `in(attr1,"val1","val2")`.
+
+[source,java,linenums,options="nowrap"]
+----
+      final RqlQueryModel preProcessedModel = RqlParser.preProcessFilter(
+            model,
+            List.of(  //<1> <2> <3>
+               new NotNeToEqRqlFilterPreProcessor(),
+               new AndNeToNotInRqlFilterPreProcessor(),
+               new OrEqToInRqlFilterPreProcessor()
+            )
+      );
+----
+
+<1> Each pre-processor must implement the `RqlFilterPreProcessor` interface.
+<2> You can create your own pre-processors by implementing this interface and adding them to the list.
+<3> The pre-processors are applied in the order they are defined in the list. This means that the first
+pre-processor will be applied first, then the second will be applied on the result of the first transformation and so on.
+
 [[rql-query-dsl]]
 == RQL to QueryDSL
 

--- a/semanticstack-rql-2-querydsl/src/main/java/com/boschsemanticstack/rql/querydsl/resolvers/AbstractPathPredicateResolver.java
+++ b/semanticstack-rql-2-querydsl/src/main/java/com/boschsemanticstack/rql/querydsl/resolvers/AbstractPathPredicateResolver.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import com.boschsemanticstack.rql.exceptions.NoSuchFieldQueryException;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.SimpleExpression;
+
 import jakarta.validation.constraints.NotNull;
 
 /**

--- a/semanticstack-rql-2-querydsl/src/main/java/com/boschsemanticstack/rql/querydsl/resolvers/BeanPathResolver.java
+++ b/semanticstack-rql-2-querydsl/src/main/java/com/boschsemanticstack/rql/querydsl/resolvers/BeanPathResolver.java
@@ -18,7 +18,6 @@ import java.lang.reflect.Method;
 import java.util.Queue;
 
 import com.boschsemanticstack.rql.model.v1.RqlFilter;
-
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BeanPath;
 import com.querydsl.core.types.dsl.SimpleExpression;

--- a/semanticstack-rql-2-querydsl/src/main/java/com/boschsemanticstack/rql/querydsl/resolvers/CollectionPathResolver.java
+++ b/semanticstack-rql-2-querydsl/src/main/java/com/boschsemanticstack/rql/querydsl/resolvers/CollectionPathResolver.java
@@ -21,7 +21,6 @@ import java.util.Queue;
 
 import com.boschsemanticstack.rql.exceptions.NoSuchFieldQueryException;
 import com.boschsemanticstack.rql.model.v1.RqlFilter;
-
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.CollectionPathBase;

--- a/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/RqlFilterPreProcessor.java
+++ b/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/RqlFilterPreProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.model.v1;
+
+import java.util.List;
+
+import com.boschsemanticstack.rql.model.v1.impl.RqlFilterImpl;
+
+/**
+ * A preprocessor for RQL filter expressions.
+ * This interface is used to conditionally transform RQL filters by
+ * replacing matching subtrees with the result of a predefined transformation.
+ */
+public interface RqlFilterPreProcessor {
+
+   boolean matches( RqlFilter filter );
+
+   /**
+    * The entry point of the transformation.
+    * This method will visit the subtree recursively and replace the matching parts.
+    *
+    * @param filter the subtree to visit
+    * @return the transformed subtree.
+    */
+   default RqlFilter visit( final RqlFilter filter ) {
+      if ( matches( filter ) ) {
+         return replaceSubTree( filter );
+      }
+      if ( filter.getChildCount() == 0 ) {
+         return filter;
+      }
+      final List<RqlFilter> originalChildren = filter.getChildren();
+      final List<RqlFilter> visitedChildren = originalChildren.stream().map( this::visit ).toList();
+      if ( originalChildren.equals( visitedChildren ) ) {
+         return filter;
+      }
+      return new RqlFilterImpl( filter.getFilterType(), visitedChildren );
+   }
+
+   RqlFilter replaceSubTree( RqlFilter filter );
+
+}

--- a/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/AndNeToNotInRqlFilterPreProcessor.java
+++ b/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/AndNeToNotInRqlFilterPreProcessor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.model.v1.impl.preprocessor;
+
+import java.util.List;
+
+import com.boschsemanticstack.rql.model.v1.RqlFilter;
+import com.boschsemanticstack.rql.model.v1.RqlFilterPreProcessor;
+import com.boschsemanticstack.rql.model.v1.impl.RqlFilterImpl;
+
+/**
+ * This preprocessor replaces an AND filter with NE operators with a NOT IN
+ * filter if they have the same attribute.
+ *
+ * <p>
+ * Example:
+ * <pre>
+ * and(
+ *    ne(attribute, "value1"),
+ *    ne(attribute, "value2")
+ * )
+ * </pre>
+ * becomes
+ * <pre>
+ *    not(in(attribute, "value1", "value2"))
+ * </pre>
+ */
+public class AndNeToNotInRqlFilterPreProcessor
+      extends BaseRqlFilterPreProcessor implements RqlFilterPreProcessor {
+
+   @Override
+   public boolean matches( final RqlFilter filter ) {
+      return filter.getFilterType() == RqlFilter.FilterType.AND
+             && allChildrenHaveOperator( filter, RqlFilter.Operator.NE )
+             && allChildrenHaveSameAttribute( filter );
+   }
+
+   @Override
+   public RqlFilter replaceSubTree( final RqlFilter filter ) {
+      final String attribute = firstChildAttribute( filter );
+      final List<Object> values = childValuesAsList( filter );
+      return new RqlFilterImpl( RqlFilter.FilterType.NOT,
+            new RqlFilterImpl( attribute, RqlFilter.Operator.IN, values ) );
+   }
+}

--- a/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/BaseRqlFilterPreProcessor.java
+++ b/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/BaseRqlFilterPreProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.model.v1.impl.preprocessor;
+
+import java.util.List;
+
+import com.boschsemanticstack.rql.model.v1.RqlFilter;
+
+/**
+ * Base class for RQL filter pre-processors.
+ *
+ * <p>
+ * This class provides convenience methods to check the structure of RQL
+ * filters and to extract information from them. It is intended to be
+ * extended by specific pre-processor implementations.
+ */
+public class BaseRqlFilterPreProcessor {
+
+   protected boolean isUnary( final RqlFilter filter ) {
+      return filter.getChildCount() == 1;
+   }
+
+   protected boolean isBinary( final RqlFilter filter ) {
+      return filter.getChildCount() == 2;
+   }
+
+   protected boolean allChildrenHaveOperator(
+         final RqlFilter filter,
+         final RqlFilter.Operator operator ) {
+      return filter.getChildren().stream()
+            .allMatch( child -> child.getOperator() == operator );
+   }
+
+   protected boolean allChildrenHaveSameAttribute( final RqlFilter filter ) {
+      return filter.getChildren().stream()
+                   .map( RqlFilter::getAttribute )
+                   .distinct()
+                   .count() == 1L;
+   }
+
+   protected RqlFilter.Operator firstChildOperator( final RqlFilter filter ) {
+      return filter.getChildren().get( 0 ).getOperator();
+   }
+
+   protected String firstChildAttribute( final RqlFilter filter ) {
+      return filter.getChildren().get( 0 ).getAttribute();
+   }
+
+   protected List<Object> childValuesAsList( final RqlFilter filter ) {
+      return filter.getChildren().stream()
+            .map( RqlFilter::getValue )
+            .toList();
+   }
+}

--- a/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/NotNeToEqRqlFilterPreProcessor.java
+++ b/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/NotNeToEqRqlFilterPreProcessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.model.v1.impl.preprocessor;
+
+import java.util.List;
+
+import com.boschsemanticstack.rql.model.v1.RqlFilter;
+import com.boschsemanticstack.rql.model.v1.RqlFilterPreProcessor;
+import com.boschsemanticstack.rql.model.v1.impl.RqlFilterImpl;
+
+/**
+ * This preprocessor replaces a NOT filter with NE operator with a filter
+ * using EQ operator.
+ *
+ * <p>
+ * Example:
+ * <pre>
+ * not(
+ *    ne(attribute, "value1")
+ * )
+ * </pre>
+ * becomes
+ * <pre>
+ *    eq(attribute, "value1")
+ * </pre>
+ */
+public class NotNeToEqRqlFilterPreProcessor
+      extends BaseRqlFilterPreProcessor implements RqlFilterPreProcessor {
+
+   @Override
+   public boolean matches( final RqlFilter filter ) {
+      return filter.getFilterType() == RqlFilter.FilterType.NOT
+             && isUnary( filter )
+             && firstChildOperator( filter ) == RqlFilter.Operator.NE;
+   }
+
+   @Override
+   public RqlFilter replaceSubTree( final RqlFilter filter ) {
+      final String attribute = firstChildAttribute( filter );
+      final List<Object> values = childValuesAsList( filter );
+      return new RqlFilterImpl( attribute, RqlFilter.Operator.EQ, values );
+   }
+}

--- a/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/OrEqToInRqlFilterPreProcessor.java
+++ b/semanticstack-rql-model/src/main/java/com/boschsemanticstack/rql/model/v1/impl/preprocessor/OrEqToInRqlFilterPreProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.model.v1.impl.preprocessor;
+
+import java.util.List;
+
+import com.boschsemanticstack.rql.model.v1.RqlFilter;
+import com.boschsemanticstack.rql.model.v1.RqlFilterPreProcessor;
+import com.boschsemanticstack.rql.model.v1.impl.RqlFilterImpl;
+
+/**
+ * This preprocessor replaces an OR filter with EQ operators with an IN
+ * filter if they have the same attribute.
+ *
+ * <p>
+ * Example:
+ * <pre>
+ * or(
+ *    eq(attribute, "value1"),
+ *    eq(attribute, "value2")
+ * )
+ * </pre>
+ * becomes
+ * <pre>
+ *    in(attribute, "value1", "value2")
+ * </pre>
+ */
+public class OrEqToInRqlFilterPreProcessor
+      extends BaseRqlFilterPreProcessor implements RqlFilterPreProcessor {
+
+   @Override
+   public boolean matches( final RqlFilter filter ) {
+      return filter.getFilterType() == RqlFilter.FilterType.OR
+             && allChildrenHaveOperator( filter, RqlFilter.Operator.EQ )
+             && allChildrenHaveSameAttribute( filter );
+   }
+
+   @Override
+   public RqlFilter replaceSubTree( final RqlFilter filter ) {
+      final String attribute = firstChildAttribute( filter );
+      final List<Object> values = childValuesAsList( filter );
+      return new RqlFilterImpl( attribute, RqlFilter.Operator.IN, values );
+   }
+}

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlFilterAssert.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlFilterAssert.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.assertj;
+
+import java.util.Objects;
+
+import com.boschsemanticstack.rql.model.v1.RqlFilter;
+
+import org.assertj.core.api.AbstractObjectAssert;
+
+public class RqlFilterAssert extends AbstractObjectAssert<RqlFilterAssert, RqlFilter> {
+
+   protected RqlFilterAssert( RqlFilter rqlFilter ) {
+      super( rqlFilter, RqlFilterAssert.class );
+   }
+
+   public static RqlFilterAssert assertThat( RqlFilter actual ) {
+      return new RqlFilterAssert( actual );
+   }
+
+   public RqlFilterAssert hasFilterType( RqlFilter.FilterType filterType ) {
+      isNotNull();
+      if ( actual.getFilterType() != filterType ) {
+         failWithMessage( "Expected filter type to be <%s> but was <%s>", filterType, actual.getFilterType() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert hasAttribute( String attribute ) {
+      isNotNull();
+      if ( !Objects.equals( actual.getAttribute(), attribute ) ) {
+         failWithMessage( "Expected filter to contain attribute <%s> but was <%s>", attribute, actual.getAttribute() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert hasOperator( RqlFilter.Operator operator ) {
+      isNotNull();
+      if ( actual.getOperator() != operator ) {
+         failWithMessage( "Expected filter operator to be <%s> but was <%s>", operator, actual.getOperator() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert hasNoChildren() {
+      isNotNull();
+      if ( actual.getChildCount() != 0 ) {
+         failWithMessage( "Expected filter to have no children but was <%s>", actual.getChildCount() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert hasChildCount( int count ) {
+      isNotNull();
+      if ( actual.getChildCount() != count ) {
+         failWithMessage( "Expected filter to have <%s> children but was <%s>", count, actual.getChildCount() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert getFirstChild() {
+      return getChild( 0 );
+   }
+
+   public RqlFilterAssert getChild( int index ) {
+      isNotNull();
+      if ( index < 0 || index >= actual.getChildCount() ) {
+         failWithMessage( "Expected filter to have child at index <%s> but was out of bounds", index );
+      }
+      return new RqlFilterAssert( actual.getChildren().get( index ) );
+   }
+
+   public RqlFilterAssert valueIsNull() {
+      isNotNull();
+      if ( actual.getValue() != null ) {
+         failWithMessage( "Expected filter to contain null value but was <%s>", actual.getValue() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert valueIsEqualTo( Object value ) {
+      isNotNull();
+      if ( !Objects.equals( actual.getValue(), value ) ) {
+         failWithMessage( "Expected filter to contain value <%s> but was <%s>", value, actual.getValue() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert valuesContainExactly( Object... values ) {
+      isNotNull();
+      if ( actual.getValues().size() != values.length ) {
+         failWithMessage( "Expected filter to contain <%s> values but was <%s>", values.length, actual.getValues().size() );
+      }
+      for ( int i = 0; i < values.length; i++ ) {
+         if ( !Objects.equals( actual.getValues().get( i ), values[i] ) ) {
+            failWithMessage( "Expected filter to contain value <%s> at index <%d> but was <%s>", values[i], i, actual.getValues().get( i ) );
+         }
+      }
+      return this;
+   }
+}

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlOptionsAssert.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlOptionsAssert.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.assertj;
+
+import java.util.Objects;
+
+import com.boschsemanticstack.rql.model.v1.RqlOptions;
+import com.boschsemanticstack.rql.model.v1.impl.RqlCursorImpl;
+import com.boschsemanticstack.rql.model.v1.impl.RqlFieldDirectionImpl;
+
+import org.assertj.core.api.AbstractAssert;
+
+public class RqlOptionsAssert extends AbstractAssert<RqlOptionsAssert, RqlOptions> {
+
+   protected RqlOptionsAssert( RqlOptions rqlOptions ) {
+      super( rqlOptions, RqlOptionsAssert.class );
+   }
+
+   public static RqlOptionsAssert assertThat( RqlOptions actual ) {
+      return new RqlOptionsAssert( actual );
+   }
+
+   public RqlOptionsAssert hasNoSlice() {
+      isNotNull();
+      if ( actual.getSlice().isPresent() ) {
+         failWithMessage( "Expected no slice but was <%s>", actual.getSlice().get() );
+      }
+      return this;
+   }
+
+   public RqlOptionsAssert hasLimit( int limit ) {
+      isNotNull();
+      if ( actual.getSlice().isPresent() && actual.getSlice().get().limit() != limit ) {
+         failWithMessage( "Expected limit <%s> but was <%s>", limit, actual.getSlice().get().limit() );
+      }
+      return this;
+   }
+
+   public RqlOptionsAssert hasOffset( int offset ) {
+      isNotNull();
+      if ( actual.getSlice().isPresent() && actual.getSlice().get().offset() != offset ) {
+         failWithMessage( "Expected offset <%s> but was <%s>", offset, actual.getSlice().get().offset() );
+      }
+      return this;
+   }
+
+   public RqlOptionsAssert hasNoOrder() {
+      isNotNull();
+      if ( !actual.getOrder().isEmpty() ) {
+         failWithMessage( "Expected no order but was <%s>", actual.getOrder() );
+      }
+      return this;
+   }
+
+   public RqlOptionsAssert isNotEmpty() {
+      isNotNull();
+      if ( actual.isEmpty() ) {
+         failWithMessage( "Expected options to not be empty but was" );
+      }
+      return this;
+   }
+
+   public RqlOptionsAssert containsCursor( RqlCursorImpl rqlCursor ) {
+      isNotEmpty();
+      if ( actual.getCursor().isEmpty() ) {
+         failWithMessage( "Expected options to contain a cursor but was empty" );
+      }
+      if ( !actual.getCursor().get().equals( rqlCursor ) ) {
+         failWithMessage( "Expected options to contain cursor <%s> but was <%s>", rqlCursor, actual.getCursor().get() );
+      }
+      return this;
+   }
+
+   public RqlOptionsAssert orderContainsExactly( RqlFieldDirectionImpl... fieldDirection ) {
+      isNotEmpty();
+      if ( actual.getOrder().isEmpty() ) {
+         failWithMessage( "Expected options to contain order but was empty" );
+      }
+      if ( actual.getOrder().fieldDirections().size() != fieldDirection.length ) {
+         failWithMessage( "Expected options to contain order of size <%d> but was <%d>", fieldDirection.length, actual.getOrder().fieldDirections().size() );
+      }
+      for ( int i = 0; i < fieldDirection.length; i++ ) {
+         if ( !Objects.equals( actual.getOrder().fieldDirections().get( i ), fieldDirection[i] ) ) {
+            failWithMessage( "Expected options to contain order <%s> at index <%d> but was <%s>", fieldDirection[i], i,
+                  actual.getOrder().fieldDirections().get( i ) );
+         }
+      }
+      return this;
+   }
+}

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlQueryModelAssert.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlQueryModelAssert.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.assertj;
+
+import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
+import com.boschsemanticstack.rql.parser.v1.RqlParser;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.StringAssert;
+
+public class RqlQueryModelAssert extends AbstractAssert<RqlQueryModelAssert, RqlQueryModel> {
+
+   protected RqlQueryModelAssert( RqlQueryModel actual ) {
+      super( actual, RqlQueryModelAssert.class );
+   }
+
+   public static RqlQueryModelAssert assertThat( RqlQueryModel actual ) {
+      return new RqlQueryModelAssert( actual );
+   }
+
+   public RqlQueryModelAssert isEmpty() {
+      isNotNull();
+      if ( !actual.isEmpty() ) {
+         failWithMessage( "Expected query model to be empty but was <%s>", actual );
+      }
+      return this;
+   }
+
+   public RqlQueryModelAssert isNotEmpty() {
+      isNotNull();
+      if ( actual.isEmpty() ) {
+         failWithMessage( "Expected query model to not be empty but was" );
+      }
+      return this;
+   }
+
+   public RqlQueryModelAssert hasNoFilter() {
+      isNotNull();
+      if ( actual.getFilter().isPresent() ) {
+         failWithMessage( "Expected no filter but was <%s>", actual.getFilter().get() );
+      }
+      return this;
+   }
+
+   public RqlFilterAssert filter() {
+      isNotNull();
+      if ( actual.getFilter().isPresent() ) {
+         return RqlFilterAssert.assertThat( actual.getFilter().get() );
+      } else {
+         failWithMessage( "Expected filter to be present but was not" );
+         return null; // This line will never be reached due to the exception thrown above
+      }
+   }
+
+   public RqlOptionsAssert options() {
+      isNotNull();
+      return RqlOptionsAssert.assertThat( actual.getOptions() );
+   }
+
+   public RqlQueryModelAssert hasNoOptions() {
+      isNotNull();
+      if ( !actual.getOptions().isEmpty() ) {
+         failWithMessage( "Expected no options but was <%s>", actual.getOptions() );
+      }
+      return this;
+   }
+
+   public RqlSelectAssert select() {
+      isNotNull();
+      if ( !actual.getSelect().isEmpty() ) {
+         return RqlSelectAssert.assertThat( actual.getSelect() );
+      } else {
+         failWithMessage( "Expected select to be present but was not" );
+         return null; // This line will never be reached due to the exception thrown above
+      }
+   }
+
+   public RqlQueryModelAssert hasNoSelect() {
+      isNotNull();
+      if ( !actual.getSelect().isEmpty() ) {
+         failWithMessage( "Expected no select but was <%s>", actual.getSelect() );
+      }
+      return this;
+   }
+
+   public StringAssert queryString() {
+      isNotNull();
+      return new StringAssert( RqlParser.toString( actual ) );
+   }
+}

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlSelectAssert.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/assertj/RqlSelectAssert.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.assertj;
+
+import java.util.Objects;
+
+import com.boschsemanticstack.rql.model.v1.RqlSelect;
+
+import org.assertj.core.api.AbstractAssert;
+
+public class RqlSelectAssert extends AbstractAssert<RqlSelectAssert, RqlSelect> {
+
+   protected RqlSelectAssert( RqlSelect rqlSelect ) {
+      super( rqlSelect, RqlSelectAssert.class );
+   }
+
+   public static RqlSelectAssert assertThat( RqlSelect actual ) {
+      return new RqlSelectAssert( actual );
+   }
+
+   public RqlSelectAssert attributesContainExactly( String... attributes ) {
+      isNotNull();
+      if ( actual.attributes().size() != attributes.length ) {
+         failWithMessage( "Expected <%s> attributes but was <%s>", attributes.length, actual.attributes().size() );
+      }
+      for ( int i = 0; i < attributes.length; i++ ) {
+         if ( !Objects.equals( actual.attributes().get( i ), attributes[i] ) ) {
+            failWithMessage( "Expected filter to contain attribute <%s> at index <%d> but was <%s>", attributes[i], i, actual.attributes().get( i ) );
+         }
+      }
+      return this;
+   }
+}

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlFloatingPointTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlFloatingPointTest.java
@@ -13,7 +13,7 @@
 
 package com.boschsemanticstack.rql.language;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
 
 import java.math.BigDecimal;
 import java.util.stream.Stream;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-  
+
 class RqlFloatingPointTest {
 
    @ParameterizedTest
@@ -34,10 +34,12 @@ class RqlFloatingPointTest {
    void shouldParseSimpleFloatingPointSyntaxIntoBigDecimal( final String expression ) {
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "id" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo( new BigDecimal( "12345.5432109876" ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "id" )
+            .valueIsEqualTo( new BigDecimal( "12345.5432109876" ) )
+            .hasNoChildren();
    }
 
    private static Stream<Arguments> expressions() {
@@ -56,9 +58,11 @@ class RqlFloatingPointTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "id" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo( new BigDecimal( "0.0" ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "id" )
+            .valueIsEqualTo( new BigDecimal( "0.0" ) )
+            .hasNoChildren();
    }
 }

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlOptionsTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlOptionsTest.java
@@ -13,16 +13,14 @@
 
 package com.boschsemanticstack.rql.language;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.boschsemanticstack.rql.exceptions.ParseException;
 import com.boschsemanticstack.rql.model.v1.RqlFieldDirection;
 import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
 import com.boschsemanticstack.rql.model.v1.impl.RqlCursorImpl;
 import com.boschsemanticstack.rql.model.v1.impl.RqlFieldDirectionImpl;
-import com.boschsemanticstack.rql.model.v1.impl.RqlSliceImpl;
 import com.boschsemanticstack.rql.parser.v1.RqlParser;
 
 import org.junit.jupiter.api.Test;
@@ -34,23 +32,24 @@ class RqlOptionsTest {
 
    @Test
    void optionsWithBracketsAroundShouldLeadToSyntaxError() {
-      final String expression = "   select=att1,att2,att3.subAtt4&filter=and(eq(att2,\"theSame\"),or(lt(att1,5),not(gt(att1,42))))&option="
-            + "(limit(0,500),sort(+att1,-att2))";
+      final String expression = """
+             select=att1,att2,att3.subAtt4\
+            &filter=and(eq(att2,"theSame"),or(lt(att1,5),not(gt(att1,42))))\
+            &option=(limit(0,500),sort(+att1,-att2))""";
 
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-
-      assertThat( throwable )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
             .isInstanceOf( ParseException.class )
             .hasMessageContaining( "extraneous input '('" );
    }
 
    @Test
    void optionsWithoutCommaShouldLeadToSyntaxError() {
-      final String expression = "select=id,name&filter=eq(id,\"47*\")&option=sort(+name,-description)limit(1,2)cursor(2)";
+      final String expression = """
+             select=id,name\
+            &filter=eq(id,"47*")\
+            &option=sort(+name,-description)limit(1,2)cursor(2)""";
 
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-
-      assertThat( throwable )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
             .isInstanceOf( ParseException.class )
             .hasMessageContaining( "extraneous input 'limit'" );
    }
@@ -75,13 +74,13 @@ class RqlOptionsTest {
 
       final RqlQueryModel sortLimitParseTree = RqlParser.from( sortLimitExpression );
 
-      assertThat( sortLimitParseTree.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      assertThat( sortLimitParseTree )
+            .options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "name", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "description", RqlFieldDirection.Direction.DESCENDING )
-            );
-
-      assertThat( sortLimitParseTree.getOptions().getCursor() ).contains( new RqlCursorImpl( "abc", 10 ) );
+            )
+            .containsCursor( new RqlCursorImpl( "abc", 10 ) );
    }
 
    @Test
@@ -90,7 +89,9 @@ class RqlOptionsTest {
 
       final RqlQueryModel sortLimitParseTree = RqlParser.from( sortLimitExpression );
 
-      assertThat( sortLimitParseTree.getOptions().getCursor() ).contains( new RqlCursorImpl( "abc", 10 ) );
+      assertThat( sortLimitParseTree )
+            .options()
+            .containsCursor( new RqlCursorImpl( "abc", 10 ) );
    }
 
    @Test
@@ -99,7 +100,9 @@ class RqlOptionsTest {
 
       final RqlQueryModel sortLimitParseTree = RqlParser.from( sortLimitExpression );
 
-      assertThat( sortLimitParseTree.getOptions().getCursor() ).contains( new RqlCursorImpl( 10 ) );
+      assertThat( sortLimitParseTree )
+            .options()
+            .containsCursor( new RqlCursorImpl( 10 ) );
    }
 
    @Test
@@ -108,13 +111,13 @@ class RqlOptionsTest {
 
       final RqlQueryModel limitSortParseTree = RqlParser.from( limitSortExpression );
 
-      assertThat( limitSortParseTree.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      assertThat( limitSortParseTree )
+            .options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "name", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "description", RqlFieldDirection.Direction.DESCENDING )
-            );
-
-      assertThat( limitSortParseTree.getOptions().getCursor() ).contains( new RqlCursorImpl( "abc", 10 ) );
+            )
+            .containsCursor( new RqlCursorImpl( "abc", 10 ) );
    }
 
    @ParameterizedTest
@@ -144,8 +147,8 @@ class RqlOptionsTest {
          "option=cursor(100),limit(10,100),sort(+id)",
    } )
    void shouldThrowMismatchInputWrongOptionSyntax( final String expression ) {
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-      assertThat( throwable ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "mismatched input" )
             .hasMessageContaining( "@[line:1" )
             .hasMessageContaining( "column" );
@@ -158,8 +161,8 @@ class RqlOptionsTest {
          "option=,sort(+id)"
    } )
    void shouldThrowExtraneousInputOptionSyntax( final String expression ) {
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-      assertThat( throwable ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "extraneous input ',' expecting {'sort', 'limit', 'cursor'}" )
             .hasMessageContaining( "@[line:1" )
             .hasMessageContaining( "column" );
@@ -170,8 +173,8 @@ class RqlOptionsTest {
          "option=sort(id)",
    } )
    void shouldNotThrowNoViableAlternativeOptionSyntax( final String expression ) {
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-      assertThat( throwable ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "missing Sign at 'id'" );
    }
 
@@ -190,7 +193,9 @@ class RqlOptionsTest {
    void shouldParseableSyntax( final String expression ) {
       final RqlQueryModel sortLimitParseTree = RqlParser.from( expression );
 
-      assertThat( sortLimitParseTree.getOptions().isEmpty() ).isFalse();
+      assertThat( sortLimitParseTree )
+            .options()
+            .isNotEmpty();
    }
 
    @Test
@@ -199,13 +204,14 @@ class RqlOptionsTest {
 
       final RqlQueryModel sortLimitParseTree = RqlParser.from( sortLimitExpression );
 
-      assertThat( sortLimitParseTree.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      assertThat( sortLimitParseTree )
+            .options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "name", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "description", RqlFieldDirection.Direction.DESCENDING )
-            );
-
-      assertThat( sortLimitParseTree.getOptions().getSlice() ).contains( new RqlSliceImpl( 5, 10 ) );
+            )
+            .hasOffset( 5 )
+            .hasLimit( 10 );
    }
 
    @Test
@@ -214,13 +220,14 @@ class RqlOptionsTest {
 
       final RqlQueryModel limitSortParseTree = RqlParser.from( limitSortExpression );
 
-      assertThat( limitSortParseTree.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      assertThat( limitSortParseTree )
+            .options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "name", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "description", RqlFieldDirection.Direction.DESCENDING )
-            );
-
-      assertThat( limitSortParseTree.getOptions().getSlice() ).contains( new RqlSliceImpl( 5, 10 ) );
+            )
+            .hasOffset( 5 )
+            .hasLimit( 10 );
    }
 
    @Test
@@ -229,6 +236,8 @@ class RqlOptionsTest {
 
       final RqlQueryModel limitSortParseTree = RqlParser.from( limitSortExpression );
 
-      assertThat( limitSortParseTree.getOptions().getCursor() ).contains( new RqlCursorImpl( "null", 10 ) );
+      assertThat( limitSortParseTree )
+            .options()
+            .containsCursor( new RqlCursorImpl( "null", 10 ) );
    }
 }

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlPartialInputTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlPartialInputTest.java
@@ -13,8 +13,8 @@
 
 package com.boschsemanticstack.rql.language;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.boschsemanticstack.rql.exceptions.ParseException;
 import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
@@ -29,9 +29,8 @@ class RqlPartialInputTest {
    void nullInputShouldThrowParseException() {
       final String expression = null;
 
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-
-      assertThat( throwable ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "Input was null" );
    }
 
@@ -41,9 +40,9 @@ class RqlPartialInputTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.isEmpty() )
+      assertThat( model )
             .describedAs( "Parsing empty string should lead to an empty model." )
-            .isTrue();
+            .isEmpty();
    }
 
    @Test
@@ -52,13 +51,13 @@ class RqlPartialInputTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter() )
+      assertThat( model )
             .describedAs( "Parsing select only should lead to an empty filter." )
-            .isEmpty();
-      assertThat( model.getOptions().isEmpty() )
+            .hasNoFilter()
             .describedAs( "Parsing select only string should lead to empty options." )
-            .isTrue();
-      assertThat( model.getSelect().attributes() ).containsExactly( "id", "name" );
+            .hasNoOptions()
+            .select()
+            .attributesContainExactly( "id", "name" );
    }
 
    @Test
@@ -67,10 +66,10 @@ class RqlPartialInputTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getSelect().isEmpty() ).isTrue();
-      assertThat( model.getFilter() ).isEmpty();
-
-      assertThat( model.getOptions().isEmpty() ).isFalse();
-      assertThat( model.getOptions().getCursor() ).contains( new RqlCursorImpl( 500 ) );
+      assertThat( model )
+            .hasNoFilter()
+            .hasNoSelect()
+            .options()
+            .containsCursor( new RqlCursorImpl( 500 ) );
    }
 }

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlRepresentationTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlRepresentationTest.java
@@ -13,17 +13,17 @@
 
 package com.boschsemanticstack.rql.language;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.tuple;
 
+import com.boschsemanticstack.rql.assertj.RqlFilterAssert;
+import com.boschsemanticstack.rql.assertj.RqlQueryModelAssert;
 import com.boschsemanticstack.rql.exceptions.ParseException;
 import com.boschsemanticstack.rql.model.v1.RqlFieldDirection;
 import com.boschsemanticstack.rql.model.v1.RqlFilter;
 import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
+import com.boschsemanticstack.rql.model.v1.impl.RqlCursorImpl;
 import com.boschsemanticstack.rql.model.v1.impl.RqlFieldDirectionImpl;
-import com.boschsemanticstack.rql.model.v1.impl.RqlSliceImpl;
 import com.boschsemanticstack.rql.parser.v1.RqlParser;
 
 import org.junit.jupiter.api.Test;
@@ -34,21 +34,24 @@ class RqlRepresentationTest {
 
    @Test
    void queryWithSlashAttributeShouldBeNotParseable() {
-      final String expression = " option=sort(+att1,-att2)"
-            + "&filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))"
-            + "&select=att1,att2,att3/subAtt4"
-            + "&option=limit(5,500)";
+      final String expression = """
+             option=sort(+att1,-att2)\
+            &filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+            &select=att1,att2,att3/subAtt4\
+            &option=limit(5,500)""";
 
-      assertThatThrownBy( () -> RqlParser.from( expression ) ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "token recognition error at: '/'" );
    }
 
    @Test
    void queryWithRandomizedDuplicateOptionShouldNotBeParsable() {
-      final String expression = " option=sort(+att1,-att2)"
-            + "&filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))"
-            + "&select=att1,att2,att3.subAtt4"
-            + "&option=limit(5,500)";
+      final String expression = """
+             option=sort(+att1,-att2)\
+            &filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+            &select=att1,att2,att3.subAtt4\
+            &option=limit(5,500)""";
 
       assertThatThrownBy( () -> RqlParser.from( expression ) ).isInstanceOf( ParseException.class )
             .hasMessageContaining( "No more than one options statement allowed" );
@@ -56,96 +59,148 @@ class RqlRepresentationTest {
 
    @ParameterizedTest
    @ValueSource( strings = {
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),limit(5,500)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=limit(5,500),sort(+att1,-att2)"
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),limit(5,500)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=limit(5,500),sort(+att1,-att2)"""
    } )
    void queryWithRandomizedOrderShouldBeParsable( final String expression ) {
       final RqlQueryModel query = RqlParser.from( expression );
 
-      assertThat( query.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      final RqlQueryModelAssert modelAssert = assertThat( query );
+      modelAssert.options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "att1", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "att2", RqlFieldDirection.Direction.DESCENDING )
-            );
-      assertThat( query.getOptions().getSlice().get().limit() ).isEqualTo( 500 );
-      assertThat( query.getOptions().getSlice().get().offset() ).isEqualTo( 5 );
-      assertThat( query.getSelect().attributes() )
-            .containsExactly( "att1", "att2", "att3.subAtt4" );
-
-      assertThat( query.getFilter().get().getChildren() ).extracting( RqlFilter::getOperator,
-                  RqlFilter::getAttribute, RqlFilter::getValue )
-            .containsExactly(
-                  tuple( RqlFilter.Operator.EQ, "att2", "theSame" ), tuple( RqlFilter.Operator.LT, "att1", 5 ),
-                  tuple( RqlFilter.Operator.GT, "att1", 42 ) );
+            )
+            .hasLimit( 500 )
+            .hasOffset( 5 );
+      modelAssert.select()
+            .attributesContainExactly( "att1", "att2", "att3.subAtt4" );
+      final RqlFilterAssert filterAssert = modelAssert.filter()
+            .hasChildCount( 3 );
+      filterAssert.getFirstChild()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "att2" )
+            .valueIsEqualTo( "theSame" );
+      filterAssert.getChild( 1 )
+            .hasOperator( RqlFilter.Operator.LT )
+            .hasAttribute( "att1" )
+            .valueIsEqualTo( 5 );
+      filterAssert.getChild( 2 )
+            .hasOperator( RqlFilter.Operator.GT )
+            .hasAttribute( "att1" )
+            .valueIsEqualTo( 42 );
    }
 
    @ParameterizedTest
    @ValueSource( strings = {
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),cursor(500)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(500),sort(+att1,-att2)"
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),cursor(500)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor(500),sort(+att1,-att2)"""
    } )
    void queryWithRandomizedOrderAndCursorShouldBeParsable( final String expression ) {
       final RqlQueryModel query = RqlParser.from( expression );
 
-      assertThat( query.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      final RqlQueryModelAssert modelAssert = assertThat( query );
+      modelAssert.options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "att1", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "att2", RqlFieldDirection.Direction.DESCENDING )
-            );
-      assertThat( query.getOptions().getCursor().get().limit() ).isEqualTo( 500 );
-      assertThat( query.getSelect().attributes() )
-            .containsExactly( "att1", "att2", "att3.subAtt4" );
-
-      assertThat( query.getFilter().get().getChildren() ).extracting( RqlFilter::getOperator,
-                  RqlFilter::getAttribute, RqlFilter::getValue )
-            .containsExactly(
-                  tuple( RqlFilter.Operator.EQ, "att2", "theSame" ),
-                  tuple( RqlFilter.Operator.LT, "att1", 5 ),
-                  tuple( RqlFilter.Operator.GT, "att1", 42 ) );
+            )
+            .containsCursor( new RqlCursorImpl( 500 ) );
+      modelAssert.select()
+            .attributesContainExactly( "att1", "att2", "att3.subAtt4" );
+      final RqlFilterAssert filterAssert = modelAssert.filter()
+            .hasChildCount( 3 );
+      filterAssert.getFirstChild()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "att2" )
+            .valueIsEqualTo( "theSame" );
+      filterAssert.getChild( 1 )
+            .hasOperator( RqlFilter.Operator.LT )
+            .hasAttribute( "att1" )
+            .valueIsEqualTo( 5 );
+      filterAssert.getChild( 2 )
+            .hasOperator( RqlFilter.Operator.GT )
+            .hasAttribute( "att1" )
+            .valueIsEqualTo( 42 );
    }
 
    @ParameterizedTest
    @ValueSource( strings = {
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),cursor(\"a\",500)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(\"a\",500),sort(+att1,-att2)"
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),cursor("a",500)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor("a",500),sort(+att1,-att2)"""
    } )
    void queryWithRandomizedOrderAndCursorStartShouldBeParsable( final String expression ) {
       final RqlQueryModel query = RqlParser.from( expression );
 
-      assertThat( query.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      final RqlQueryModelAssert modelAssert = assertThat( query );
+      modelAssert.options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "att1", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "att2", RqlFieldDirection.Direction.DESCENDING )
-            );
-      assertThat( query.getOptions().getCursor().get().limit() ).isEqualTo( 500 );
-      assertThat( query.getOptions().getCursor().get().cursor() ).contains( "a" );
-      assertThat( query.getSelect().attributes() )
-            .containsExactly( "att1", "att2", "att3.subAtt4" );
-
-      assertThat( query.getFilter().get().getChildren() ).extracting( RqlFilter::getOperator,
-                  RqlFilter::getAttribute, RqlFilter::getValue )
-            .containsExactly(
-                  tuple( RqlFilter.Operator.EQ, "att2", "theSame" ),
-                  tuple( RqlFilter.Operator.LT, "att1", 5 ),
-                  tuple( RqlFilter.Operator.GT, "att1", 42 ) );
+            )
+            .containsCursor( new RqlCursorImpl( "a", 500 ) );
+      modelAssert.select()
+            .attributesContainExactly( "att1", "att2", "att3.subAtt4" );
+      final RqlFilterAssert filterAssert = modelAssert.filter()
+            .hasChildCount( 3 );
+      filterAssert.getFirstChild()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "att2" )
+            .valueIsEqualTo( "theSame" );
+      filterAssert.getChild( 1 )
+            .hasOperator( RqlFilter.Operator.LT )
+            .hasAttribute( "att1" )
+            .valueIsEqualTo( 5 );
+      filterAssert.getChild( 2 )
+            .hasOperator( RqlFilter.Operator.GT )
+            .hasAttribute( "att1" )
+            .valueIsEqualTo( 42 );
    }
 
    @ParameterizedTest
    @ValueSource( strings = {
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(\"a\",500),sort(+att1,"
-               + "-att2),limit(100,0)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),cursor(\"a\","
-               + "500),limit(100,0)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),limit(100,0),"
-               + "cursor(\"a\",500)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),cursor(\"a\","
-               + "500),limit(100,0)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=sort(+att1,-att2),limit(100,0),"
-               + "cursor(500)"
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor("a",500),sort(+att1,-att2),limit(100,0)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),cursor("a",500),limit(100,0)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),limit(100,0),cursor("a",500)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),cursor("a",500),limit(100,0)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=sort(+att1,-att2),limit(100,0),cursor(500)"""
    } )
    void shouldThrowExtraneousInputOptionSyntax( final String expression ) {
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-      assertThat( throwable ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "extraneous input ',' expecting {<EOF>, '&'}" )
             .hasMessageContaining( "@[line:1" )
             .hasMessageContaining( "column" );
@@ -153,24 +208,42 @@ class RqlRepresentationTest {
 
    @ParameterizedTest
    @ValueSource( strings = {
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(\"a\",500),cursor(\"a\",0)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(0),cursor(500),sort"
-               + "(+att1,-att2)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=limit(10,500),limit(10,10)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=limit(10,500),limit(10,10),sort"
-               + "(+att1,-att2)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(0),limit(10,100),"
-               + "sort(+att1,-att2)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=cursor(\"a\",500),limit(10,100),"
-               + "sort(+att1,-att2)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=limit(100,0),cursor(500),sort"
-               + "(+att1,-att2)",
-         "filter=and(eq(att2,\"theSame\"),lt(att1,5),gt(att1,42))&select=att1,att2,att3.subAtt4&option=limit(100,0),cursor(\"a\",500),"
-               + "sort(+att1,-att2)"
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor("a",500),cursor("a",0)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor(0),cursor(500),sort(+att1,-att2)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=limit(10,500),limit(10,10)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=limit(10,500),limit(10,10),sort(+att1,-att2)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor(0),limit(10,100),sort(+att1,-att2)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=cursor("a",500),limit(10,100),sort(+att1,-att2)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=limit(100,0),cursor(500),sort(+att1,-att2)""",
+         """
+                filter=and(eq(att2,"theSame"),lt(att1,5),gt(att1,42))\
+               &select=att1,att2,att3.subAtt4\
+               &option=limit(100,0),cursor("a",500),sort(+att1,-att2)"""
    } )
    void shouldThrowMismatchInputWrongOptionSyntax( final String expression ) {
-      final Throwable throwable = catchThrowable( () -> RqlParser.from( expression ) );
-      assertThat( throwable ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "mismatched input" )
             .hasMessageContaining( "@[line:1" )
             .hasMessageContaining( "column" );
@@ -179,22 +252,27 @@ class RqlRepresentationTest {
    @Test
    void shouldParseNewSyntaxWithSelectEqualsWithoutParens() {
       // GIVEN
-      final String expression = "select=id,name&filter=eq(id,\"4711\")&option=sort(+name,-description),limit(5,10)";
+      final String expression = """
+             select=id,name\
+            &filter=eq(id,"4711")\
+            &option=sort(+name,-description),limit(5,10)""";
 
       // WHEN
       final RqlQueryModel model = RqlParser.from( expression );
 
       // THEN
-      assertThat( model.getSelect().attributes() ).containsExactly( "id", "name" );
-
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getValues() ).containsExactly( "4711" );
-
-      assertThat( model.getOptions().getOrder().fieldDirections() )
-            .containsExactly(
+      final RqlQueryModelAssert modelAssert = assertThat( model );
+      modelAssert.select()
+            .attributesContainExactly( "id", "name" );
+      modelAssert.filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .valueIsEqualTo( "4711" );
+      modelAssert.options()
+            .orderContainsExactly(
                   new RqlFieldDirectionImpl( "name", RqlFieldDirection.Direction.ASCENDING ),
                   new RqlFieldDirectionImpl( "description", RqlFieldDirection.Direction.DESCENDING )
-            );
-      assertThat( model.getOptions().getSlice() ).contains( new RqlSliceImpl( 5, 10 ) );
+            )
+            .hasOffset( 5 )
+            .hasLimit( 10 );
    }
 }

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlSelectTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlSelectTest.java
@@ -13,13 +13,13 @@
 
 package com.boschsemanticstack.rql.language;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.boschsemanticstack.rql.exceptions.ParseException;
 import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
 import com.boschsemanticstack.rql.parser.v1.RqlParser;
+
 import org.junit.jupiter.api.Test;
 
 class RqlSelectTest {
@@ -28,34 +28,34 @@ class RqlSelectTest {
    void select_withRegularSyntax_shouldBeNotParsable() {
       final String queryString = RqlParser.toString(
             RqlParser.builder().select( "abc", "def/ghi", "jk.lmnop" ).build() );
-      assertThatThrownBy( () -> RqlParser.from( queryString ) ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( queryString ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "token recognition error at: '/'" );
    }
- 
+
    @Test
    void select_withRegularSyntax_shouldBeParsable() {
       final String queryString = RqlParser.toString(
             RqlParser.builder().select( "abc", "def.ghi", "jk.lmnop" ).build() );
       final RqlQueryModel parsedQueryModel = RqlParser.from( queryString );
-      assertThat( parsedQueryModel.getSelect().attributes() ).containsExactly( "abc", "def.ghi",
-            "jk.lmnop" );
+      assertThat( parsedQueryModel )
+            .select()
+            .attributesContainExactly( "abc", "def.ghi", "jk.lmnop" );
    }
 
    @Test
-   void select_withMultipleParameters_shouldBeParsable() {
+   void select_withMultipleSelects_shouldNotBeParsable() {
       final String queryString = "select=abc&select=def.ghi,jk.lmnop";
-      try {
-         RqlParser.from( queryString );
-         fail();
-      } catch ( final ParseException e ) {
-         assertThat( e ).hasMessageStartingWith( "No more than one select statement allowed" );
-      }
+      assertThatThrownBy( () -> RqlParser.from( queryString ) )
+            .isInstanceOf( ParseException.class )
+            .hasMessageStartingWith( "No more than one select statement allowed" );
    }
 
    @Test
    void select_withParameterMultiValue_shouldNotBeParsable() {
       final String queryString = "select=abc,def/ghi,jk.lmnop";
-      assertThatThrownBy( () -> RqlParser.from( queryString ) ).isInstanceOf( ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( queryString ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "token recognition error at: '/'" );
    }
 
@@ -63,26 +63,17 @@ class RqlSelectTest {
    void select_withParameterMultiValue_shouldBeParsable() {
       final String queryString = "select=abc,def.ghi,jk.lmnop";
       final RqlQueryModel parsedQueryModel = RqlParser.from( queryString );
-      assertThat( parsedQueryModel.getSelect().attributes() ).containsExactly( "abc", "def.ghi",
-            "jk.lmnop" );
-   }
-
-   @Test
-   void select_Syntax_shouldBeParsable() {
-      final String queryString = RqlParser.toString(
-            RqlParser.builder().select( "abc", "def.ghi", "jk.lmnop" ).build() );
-      final RqlQueryModel parsedQueryModel = RqlParser.from( queryString );
-      assertThat( parsedQueryModel.getSelect().attributes() ).containsExactly( "abc", "def.ghi",
-            "jk.lmnop" );
+      assertThat( parsedQueryModel )
+            .select()
+            .attributesContainExactly( "abc", "def.ghi", "jk.lmnop" );
    }
 
    @Test
    void select_Syntax_shouldBeNotParsable() {
       final String queryString = RqlParser.toString(
             RqlParser.builder().select( "abc", "def.ghi", "jk/lmnop" ).build() );
-      assertThatThrownBy(
-            () -> RqlParser.from( queryString ) ).isInstanceOf(
-                  ParseException.class )
+      assertThatThrownBy( () -> RqlParser.from( queryString ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "token recognition error at: '/'" );
    }
 }

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlTimeTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/language/RqlTimeTest.java
@@ -13,9 +13,8 @@
 
 package com.boschsemanticstack.rql.language;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -33,20 +32,18 @@ class RqlTimeTest {
    void shouldNotParseIso8601ZuluWithSecondsMissing() {
       final String expression = "filter=eq(created,2007-12-03T10:15Z)";
 
-      final Throwable thrown = catchThrowable( () -> RqlParser.from( expression ) );
-
-      assertThat( thrown ).as( "This is actually valid ISO 8601 but not supported yet" )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .as( "This is actually valid ISO 8601 but not supported yet" )
             .isInstanceOf( ParseException.class )
             .hasMessageContaining( "mismatched input" );
    }
- 
+
    @Test
    void shouldNotParseIso8601ZuluWithMinutesAndSecondsMissing() {
       final String expression = "filter=eq(created,2007-12-03T10:15+4:27)";
 
-      final Throwable thrown = catchThrowable( () -> RqlParser.from( expression ) );
-
-      assertThat( thrown ).as( "This is actually valid ISO 8601 but not supported yet" )
+      assertThatThrownBy( () -> RqlParser.from( expression ) )
+            .as( "This is actually valid ISO 8601 but not supported yet" )
             .isInstanceOf( ParseException.class )
             .hasMessageContaining( "mismatched input" );
    }
@@ -57,11 +54,14 @@ class RqlTimeTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "created" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo(
-            OffsetDateTime.of( 2007, 12, 3, 10, 15, 30, 123 * 1000 * 100, ZoneOffset.UTC ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "created" )
+            .valueIsEqualTo( OffsetDateTime.of(
+                  2007, 12, 3,
+                  10, 15, 30, 123 * 1000 * 100, ZoneOffset.UTC ) )
+            .hasNoChildren();
    }
 
    @Test
@@ -70,11 +70,14 @@ class RqlTimeTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "created" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo(
-            OffsetDateTime.of( 2007, 12, 3, 10, 15, 30, 123 * 1000 * 100, ZoneOffset.UTC ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "created" )
+            .valueIsEqualTo( OffsetDateTime.of(
+                  2007, 12, 3,
+                  10, 15, 30, 123 * 1000 * 100, ZoneOffset.UTC ) )
+            .hasNoChildren();
    }
 
    @Test
@@ -83,10 +86,14 @@ class RqlTimeTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "created" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo( OffsetDateTime.of( 2007, 12, 3, 10, 15, 30, 0, ZoneOffset.UTC ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "created" )
+            .valueIsEqualTo( OffsetDateTime.of(
+                  2007, 12, 3,
+                  10, 15, 30, 0, ZoneOffset.UTC ) )
+            .hasNoChildren();
    }
 
    @Test
@@ -95,10 +102,14 @@ class RqlTimeTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "created" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo( OffsetDateTime.of( 2007, 12, 3, 10, 15, 30, 0, ZoneOffset.UTC ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "created" )
+            .valueIsEqualTo( OffsetDateTime.of(
+                  2007, 12, 3,
+                  10, 15, 30, 0, ZoneOffset.UTC ) )
+            .hasNoChildren();
    }
 
    @Test
@@ -107,11 +118,14 @@ class RqlTimeTest {
 
       final RqlQueryModel model = RqlParser.from( expression );
 
-      assertThat( model.getFilter().get().getOperator() ).isEqualTo( RqlFilter.Operator.EQ );
-      assertThat( model.getFilter().get().getAttribute() ).isEqualTo( "created" );
-      assertThat( model.getFilter().get().getValue() ).isEqualTo(
-            OffsetDateTime.of( 2007, 12, 3, 10, 15, 30, 0, ZoneOffset.ofHoursMinutes( 4, 37 ) ) );
-      assertThat( model.getFilter().get().getChildren() ).isEmpty();
+      assertThat( model )
+            .filter()
+            .hasOperator( RqlFilter.Operator.EQ )
+            .hasAttribute( "created" )
+            .valueIsEqualTo( OffsetDateTime.of(
+                  2007, 12, 3,
+                  10, 15, 30, 0, ZoneOffset.ofHoursMinutes( 4, 37 ) ) )
+            .hasNoChildren();
    }
 
    @Test

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/parser/v1/RqlParserPreProcessingTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/parser/v1/RqlParserPreProcessingTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+ *
+ * See the AUTHORS file(s) distributed with this work for additional
+ * information regarding authorship.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package com.boschsemanticstack.rql.parser.v1;
+
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.boschsemanticstack.rql.assertj.RqlFilterAssert;
+import com.boschsemanticstack.rql.model.v1.RqlFilter;
+import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
+
+import org.junit.jupiter.api.Test;
+
+class RqlParserPreProcessingTest {
+
+   @Test
+   void shouldThrowExceptionWhenModelIsNull() {
+      assertThatThrownBy( () -> RqlParser.preProcessFilter( null ) )
+            .isInstanceOf( IllegalArgumentException.class )
+            .hasMessage( "Model must not be null for pre-processing." );
+   }
+
+   @Test
+   void shouldNotChangeWhenNoFilterFound() {
+      final String expression = "select=id,name";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      assertThat( model )
+            .hasNoFilter();
+   }
+
+   @Test
+   void shouldNotChangeNotMatchingFilterExpression() {
+
+      final String expression = "filter=eq(parentId,null)";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      assertThat( model )
+            .filter()
+            .valueIsNull();
+   }
+
+   @Test
+   void shouldSimplifyFilterWithAndNeAsNotInWhenTheAttributesAreTheSame() {
+      final String expression = "filter=and(ne(xyz,\"a\"), ne(xyz,\"b\"))";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      assertThat( model )
+            .filter()
+            .hasFilterType( RqlFilter.FilterType.NOT )
+            .hasChildCount( 1 )
+            .getFirstChild()
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "xyz" )
+            .hasOperator( RqlFilter.Operator.IN )
+            .valuesContainExactly( "a", "b" );
+   }
+
+   @Test
+   void shouldSimplifyFilterWithOrEqAsInWhenTheAttributesAreTheSame() {
+      final String expression = "filter=or(eq(xyz,\"a\"), eq(xyz,\"b\"))";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      assertThat( model )
+            .filter()
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "xyz" )
+            .hasOperator( RqlFilter.Operator.IN )
+            .valuesContainExactly( "a", "b" );
+   }
+
+   @Test
+   void shouldSimplifyFilterWithNotNeAsEq() {
+      final String expression = "filter=not(ne(xyz,\"a\"))";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      assertThat( model )
+            .filter()
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "xyz" )
+            .hasOperator( RqlFilter.Operator.EQ )
+            .valueIsEqualTo( "a" );
+   }
+
+   @Test
+   void shouldSimplifyFilterWithComplexExpression() {
+      final String expression = "filter=or(not(ne(xyz,\"a\")), eq(xyz,\"b\"), eq(xyz,\"c\"))";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      assertThat( model )
+            .filter()
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "xyz" )
+            .hasOperator( RqlFilter.Operator.IN )
+            .valuesContainExactly( "a", "b", "c" );
+   }
+
+   @Test
+   void shouldNotSimplifyFilterWithOrEqExpressionWhenAttributesAreNotTheSame() {
+      final String expression = "filter=or(eq(xyz,\"a\"), eq(abc,\"b\"))";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      final RqlFilterAssert filterAssert = assertThat( model )
+            .filter()
+            .hasFilterType( RqlFilter.FilterType.OR )
+            .hasChildCount( 2 );
+      filterAssert.getFirstChild()
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "xyz" )
+            .hasOperator( RqlFilter.Operator.EQ )
+            .valuesContainExactly( "a" );
+      filterAssert.getChild( 1 )
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "abc" )
+            .hasOperator( RqlFilter.Operator.EQ )
+            .valuesContainExactly( "b" );
+   }
+
+   @Test
+   void shouldNotSimplifyFilterWithAndNeExpressionWhenAttributesAreNotTheSame() {
+      final String expression = "filter=and(ne(xyz,\"a\"), ne(abc,\"b\"))";
+
+      final RqlQueryModel parsedModel = RqlParser.from( expression );
+      final RqlQueryModel model = RqlParser.preProcessFilter( parsedModel );
+
+      final RqlFilterAssert filterAssert = assertThat( model )
+            .filter()
+            .hasFilterType( RqlFilter.FilterType.AND )
+            .hasChildCount( 2 );
+      filterAssert.getFirstChild()
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "xyz" )
+            .hasOperator( RqlFilter.Operator.NE )
+            .valuesContainExactly( "a" );
+      filterAssert.getChild( 1 )
+            .hasFilterType( RqlFilter.FilterType.VALUE )
+            .hasAttribute( "abc" )
+            .hasOperator( RqlFilter.Operator.NE )
+            .valuesContainExactly( "b" );
+   }
+}

--- a/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/parser/v1/RqlVisitorTest.java
+++ b/semanticstack-rql-parser/src/test/java/com/boschsemanticstack/rql/parser/v1/RqlVisitorTest.java
@@ -13,12 +13,12 @@
 
 package com.boschsemanticstack.rql.parser.v1;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.boschsemanticstack.rql.assertj.RqlQueryModelAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.boschsemanticstack.rql.exceptions.ParseException;
 import com.boschsemanticstack.rql.model.v1.RqlQueryModel;
+
 import org.junit.jupiter.api.Test;
 
 class RqlVisitorTest {
@@ -28,13 +28,18 @@ class RqlVisitorTest {
       final String expression = "select=id,name,nameWithSome.Extra1_9Chars.";
       final RqlQueryModel model = new RqlParserApi().parseFullQuery( expression );
 
-      assertThat( model.getSelect().attributes() ).containsExactly( "id", "name", "nameWithSome.Extra1_9Chars." );
+      assertThat( model )
+            .select()
+            .attributesContainExactly( "id", "name", "nameWithSome.Extra1_9Chars." );
    }
- 
+
    @Test
    void firstNotParseable() {
       final String expression = "select=id,name,nameWithSome/Extra1_9Chars.";
-      assertThatThrownBy( () -> new RqlParserApi().parseFullQuery( expression ) ).isInstanceOf( ParseException.class )
+      final RqlParserApi rqlParserApi = new RqlParserApi();
+
+      assertThatThrownBy( () -> rqlParserApi.parseFullQuery( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( "token recognition error at: '/'" );
    }
 
@@ -82,7 +87,10 @@ class RqlVisitorTest {
 
    private void validateParseFails( final String illegalPrefix, final String messageContaining ) {
       final String expression = "select=id," + illegalPrefix + "name";
-      assertThat( catchThrowable( () -> new RqlParserApi().parseFullQuery( expression ) ) ).isInstanceOf( ParseException.class )
+      final RqlParserApi rqlParserApi = new RqlParserApi();
+
+      assertThatThrownBy( () -> rqlParserApi.parseFullQuery( expression ) )
+            .isInstanceOf( ParseException.class )
             .hasMessageContaining( messageContaining );
    }
 }


### PR DESCRIPTION
- Define interface for filter pre-processors
- Implement example pre-processors
- Add method for filter pre-processing in RqlParser
- Cover the new functionality with tests
- Implement AssertJ assertions for the Rql model classes
- Start using the new assertions in existing tests
- Describe the new feature in the documentation

Resolves #147